### PR TITLE
add .git dir to build container

### DIFF
--- a/build_utils.go
+++ b/build_utils.go
@@ -57,7 +57,7 @@ func build(temp, name string) error {
 func makeBinary(temp, image, name string, duration time.Duration) error {
 	var (
 		c   = make(chan error)
-		cmd = exec.Command("docker", "run", "-i", "--privileged", "--name", name, "-v", path.Join(temp, "bundles")+":/go/src/github.com/docker/docker/bundles", image, "hack/make.sh", "binary", "cross", "tgz")
+		cmd = exec.Command("docker", "run", "-i", "--privileged", "--name", name, "-v", path.Join(temp, ".git")+":/go/src/github.com/docker/docker/.git", "-v", path.Join(temp, "bundles")+":/go/src/github.com/docker/docker/bundles", image, "hack/make.sh", "binary", "cross", "tgz")
 	)
 	cmd.Dir = temp
 


### PR DESCRIPTION
builds on master.dockerproject.org has been broken since 2017-02-04 because of this PR https://github.com/docker/docker/pull/30290

build logs say
```
{"log":"time=\"2017-02-05T03:19:38Z\" level=debug msg=\"Container log: \\nerror: .git directory missing and DOCKER_GITCOMMIT not specified\\n  Please either build with the .git directory accessible, or specify the\\n  exact (--short) commit hash you are building using DOCKER_GITCOMMIT for\\n  future accountability in diagnosing build issues.  Thanks!\\n\" \n","stream":"stderr","time":"2017-02-05T03:19:38.476597093Z"}
```

need the `.git` dir in the build environment