### PR TITLE
Update index to remove link to docs.master.dockerproject.com

### DIFF
--- a/static.go
+++ b/static.go
@@ -26,7 +26,7 @@ const (
 
 	<div class="wrapper">
 
-		<p>These binaries are built and updated with each commit to the master branch of Docker. Want to use that cool new feature that was just merged? Download your system's binary and check out the master docs at <a href="http://docs.master.dockerproject.com" target="_blank">docs.master.dockerproject.com</a>.</p>
+		<p>These binaries are built and updated with each commit to the master branch of Docker. Want to use that cool new feature that was just merged? Download your system's binary below.</p>
 
         <table>
             <thead>


### PR DESCRIPTION
This removes the link to `docs.master.dockerproject.com`.